### PR TITLE
Fix Q-learning in Windy World experiment

### DIFF
--- a/experiments/pacman/agents.py
+++ b/experiments/pacman/agents.py
@@ -37,10 +37,22 @@ class PacmanAgent(core.BaseControllerAgent):
     def __init__(self, agent_id):
         super(PacmanAgent, self).__init__(agent_id)
 
+    def start_game(self):
+        pass
+
+    def finish_game(self):
+        pass
+
 
 class GhostAgent(core.BaseControllerAgent):
     def __init__(self, agent_id):
         super(GhostAgent, self).__init__(agent_id)
+
+    def start_game(self):
+        pass
+
+    def finish_game(self):
+        pass
 
 
 class RandomPacmanAgent(PacmanAgent):

--- a/experiments/windy/adapter.py
+++ b/experiments/windy/adapter.py
@@ -9,8 +9,8 @@ from simulator import WindyWorldSimulator
 
 
 # Logging configuration
-logger = logging.getLogger('Windy')
-logger.setLevel(logging.DEBUG)
+logging.getLogger().setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class WindyExperiment(core.BaseExperiment):
@@ -51,7 +51,9 @@ class WindyExperiment(core.BaseExperiment):
 
             # Simulate one step
             self.simulator.step(action)
-            print self.simulator
+
+            # Show simulation state
+            logger.info('Simulator:\n{}'.format(self.simulator))
 
             # Update state to learn from the received reward
             self.agent.state = self.simulator.get_state()
@@ -126,7 +128,7 @@ class WindyAgent(core.BaseAdapterAgent):
         self.communicate(message)
 
     def send_state(self):
-        logger.info('Sending state')
+        logger.debug('Sending state')
         message = messages.StateMessage(
             agent_id=self.agent_id,
             state=self.state,
@@ -136,7 +138,7 @@ class WindyAgent(core.BaseAdapterAgent):
         return self.communicate(message)
 
     def receive_action(self):
-        logger.info('Receiving action')
+        logger.debug('Receiving action')
         action_message = self.send_state()
         self.action = action_message.action
         logger.debug('Action: {}'.format(self.action))
@@ -144,7 +146,7 @@ class WindyAgent(core.BaseAdapterAgent):
 
     def send_reward(self):
         if self.is_learning:
-            logger.info('Sending reward')
+            logger.debug('Sending reward')
             message = messages.RewardMessage(
                 agent_id=self.agent_id, state=self.state,
                 action=self.action, reward=self.reward)

--- a/experiments/windy/agents.py
+++ b/experiments/windy/agents.py
@@ -10,6 +10,12 @@ class RandomAgent(core.BaseControllerAgent):
     def __init__(self, agent_id, ally_ids, enemy_ids):
         super(RandomAgent, self).__init__(agent_id)
 
+    def start_game(self):
+        pass
+
+    def finish_game(self):
+        pass
+
     def learn(self, state, action, reward):
         pass
 
@@ -35,10 +41,16 @@ class LearningAgent(core.BaseControllerAgent):
     def set_policy(self, weights):
         self.learning.q_values = weights
 
-    def learn(self, state, action, reward):
-        self.learning.learning_rate = self.K / (self.K + self.iteration)
-        self.learning.learn(state, action, reward)
+    def start_game(self):
+        # Reduce learning rate after every game
+        self.K = self.K / (self.K + self.iteration)
+        self.learning.learning_rate = self.K
+
+    def finish_game(self):
         self.iteration += 1
+
+    def learn(self, state, action, reward):
+        self.learning.learn(state, action, reward)
 
     def act(self, state, legal_actions, explore):
         action = self.learning.act(state)

--- a/experiments/windy/agents.py
+++ b/experiments/windy/agents.py
@@ -27,11 +27,11 @@ class RandomAgent(core.BaseControllerAgent):
 class LearningAgent(core.BaseControllerAgent):
     def __init__(self, agent_id, ally_ids, enemy_ids):
         super(LearningAgent, self).__init__(agent_id)
-        self.K = 1.0  # Learning rate
+        self.K = 1.0  # Initial learning rate
         self.iteration = 1
         self.exploration_rate = 0.1
         self.learning = learning.QLearning(
-            learning_rate=0.1, discount_factor=0.9, actions=range(4))
+            learning_rate=self.K, discount_factor=0.5, actions=range(4))
         self.exploration = exploration.EGreedy(
             exploration_rate=self.exploration_rate)
 

--- a/experiments/windy/agents.py
+++ b/experiments/windy/agents.py
@@ -27,11 +27,11 @@ class RandomAgent(core.BaseControllerAgent):
 class LearningAgent(core.BaseControllerAgent):
     def __init__(self, agent_id, ally_ids, enemy_ids):
         super(LearningAgent, self).__init__(agent_id)
-        self.K = 1.0  # Initial learning rate
-        self.iteration = 1
+        self.game_number = 1
+        self.game_step = 1
         self.exploration_rate = 0.1
         self.learning = learning.QLearning(
-            learning_rate=self.K, discount_factor=0.5, actions=range(4))
+            learning_rate=0.1, discount_factor=0.9, actions=range(4))
         self.exploration = exploration.EGreedy(
             exploration_rate=self.exploration_rate)
 
@@ -42,12 +42,10 @@ class LearningAgent(core.BaseControllerAgent):
         self.learning.q_values = weights
 
     def start_game(self):
-        # Reduce learning rate after every game
-        self.K = self.K / (self.K + self.iteration)
-        self.learning.learning_rate = self.K
+        self.game_step = 1
 
     def finish_game(self):
-        self.iteration += 1
+        self.game_number += 1
 
     def learn(self, state, action, reward):
         self.learning.learn(state, action, reward)
@@ -56,9 +54,11 @@ class LearningAgent(core.BaseControllerAgent):
         action = self.learning.act(state)
 
         if explore:
-            return self.exploration.explore(action, legal_actions)
-        else:
-            return action
+            action = self.exploration.explore(action, legal_actions)
+
+        self.game_step += 1
+
+        return action
 
     def enable_learn_mode(self):
         self.learning.exploration_rate = self.exploration_rate

--- a/experiments/windy/simulator.py
+++ b/experiments/windy/simulator.py
@@ -42,6 +42,8 @@ class WindyWorldSimulator(object):
         self.num_states = self.rows*self.cols
         self.sleep = sleep
         self.score = 0
+        self.steps = 0
+        self.max_steps = 1000
 
     def __repr__(self):
         lines = [[]]
@@ -67,8 +69,8 @@ class WindyWorldSimulator(object):
         self.score = 0
 
     def get_state(self):
-        return (self.agent_coordinates[0]*self.rows +
-                self.agent_coordinates[1]*self.cols)
+        return (self.agent_coordinates[0]*self.cols +
+                self.agent_coordinates[1])
 
     def generate_state(self, action):
         # wind
@@ -101,12 +103,16 @@ class WindyWorldSimulator(object):
         return reward
 
     def is_finished(self):
-        return self.agent_coordinates == self.goal_coordinates
+        # Limit maximum number of steps to avoid stuck agents halting the
+        # entire experiment
+        return (self.agent_coordinates == self.goal_coordinates or
+                self.steps > self.max_steps)
 
     def start(self):
         self.prepate_new_episode()
 
     def step(self, action):
+        self.steps += 1
         coordinates = self.generate_state(action)
         self.score += self.get_reward()
         time.sleep(self.sleep)

--- a/experiments/windy/simulator.py
+++ b/experiments/windy/simulator.py
@@ -67,6 +67,7 @@ class WindyWorldSimulator(object):
     def prepate_new_episode(self):
         self.agent_coordinates = self.initial_coordinates
         self.score = 0
+        self.steps = 0
 
     def get_state(self):
         return (self.agent_coordinates[0]*self.cols +

--- a/experiments/windy/simulator.py
+++ b/experiments/windy/simulator.py
@@ -6,13 +6,16 @@ class WindyWorldSimulator(object):
     """Windy water example problem.
 
     The agent lives in the following world:
-    * * * W W * * * * *
-    S * * * * * * G * *
-    * * * W W * * * * *
-    * * * W W * * * * *
-    * * * * * * * * * *
-    * * A * * * * * * *
-    * * * * * * * * * *
+
+         0 1 2 3 4 5 6 7 8 9
+        --------------------
+     0 | * * * W W * * * * *
+    10 | S * * * * * * G * *
+    20 | * * * W W * * * * *
+    30 | * * * W W * * * * *
+    40 | * * * * * * * * * *
+    50 | * * A * * * * * * *
+    60 | * * * * * * * * * *
 
     where:
 
@@ -22,15 +25,26 @@ class WindyWorldSimulator(object):
     A: Agent current position
     *: Free cell
 
+    and actions:
+    0: right
+    1: up
+    2: left
+    3: down
+
     Each step gives a reward of -1, going into the water rewards -100 and
     reaching the goal state rewards 100.
     """
 
-    def __init__(self, wind_frequency=0.1, sleep=0.1):
+    def __init__(self, wind_frequency=0.0, sleep=0.1):
         super(WindyWorldSimulator, self).__init__()
         self.initial_coordinates = [1, 0]
         self.agent_coordinates = self.initial_coordinates
-        self.actions = [[0, 1], [-1, 0], [0, -1], [1, 0]]
+        self.actions = [
+            [0, 1],   # right
+            [-1, 0],  # up
+            [0, -1],  # left
+            [1, 0]    # down
+        ]
         self.rows = 7
         self.cols = 10
         self.goal_coordinates = [1, 7]

--- a/multiagentrl/controller.py
+++ b/multiagentrl/controller.py
@@ -22,8 +22,7 @@ __email__ = "matheus.v.portela@gmail.com"
 
 
 # Logging configuration
-logger = logging.getLogger('Controller')
-logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class Controller(core.BaseController):
@@ -37,10 +36,10 @@ class Controller(core.BaseController):
         self.game_number = {}
 
     def start(self):
-        logger.info('Starting')
+        logger.debug('Starting')
 
     def stop(self):
-        logger.info('Stopped')
+        logger.debug('Stopped')
 
     def is_finished(self):
         return False
@@ -70,7 +69,7 @@ class Controller(core.BaseController):
         return reply_msg
 
     def _start_experiment(self, msg):
-        logger.info('#{} Starting experiment for {}'.format(
+        logger.debug('#{} Starting experiment for {}'.format(
             msg.agent_id, msg.agent_class.__name__))
         self.map_width = msg.map_width
         self.map_height = msg.map_height
@@ -80,11 +79,11 @@ class Controller(core.BaseController):
         return messages.AcknowledgementMessage()
 
     def _finish_experiment(self, msg):
-        logger.info('#{} Finishing experiment'.format(msg.agent_id))
+        logger.debug('#{} Finishing experiment'.format(msg.agent_id))
         return messages.AcknowledgementMessage()
 
     def _start_game(self, msg):
-        logger.info('#{} Starting game'.format(msg.agent_id))
+        logger.debug('#{} Starting game'.format(msg.agent_id))
         agent_id = msg.agent_id
         ally_ids = self._get_allies(agent_id)
         enemy_ids = self._get_enemies(agent_id)
@@ -109,31 +108,31 @@ class Controller(core.BaseController):
                 id_ != agent_id]
 
     def _finish_game(self, msg):
-        logger.info('#{} Finishing game'.format(msg.agent_id))
+        logger.debug('#{} Finishing game'.format(msg.agent_id))
         self.agents[msg.agent_id].finish_game()
         self.game_number[msg.agent_id] += 1
         return messages.AcknowledgementMessage()
 
     def _receive_state(self, msg):
-        logger.info('#{} Receiving state'.format(msg.agent_id))
+        logger.debug('#{} Receiving state'.format(msg.agent_id))
         action = self.agents[msg.agent_id].act(
             msg.state, msg.legal_actions, msg.explore)
 
-        logger.info('#{} Sending action'.format(msg.agent_id))
+        logger.debug('#{} Sending action'.format(msg.agent_id))
         return messages.ActionMessage(agent_id=msg.agent_id, action=action)
 
     def _receive_reward(self, msg):
-        logger.info('#{} Receiving reward'.format(msg.agent_id))
+        logger.debug('#{} Receiving reward'.format(msg.agent_id))
         self.agents[msg.agent_id].learn(msg.state, msg.action, msg.reward)
         return messages.AcknowledgementMessage()
 
     def _send_policy_request(self, msg):
-        logger.info('#{} Sending policy'.format(msg.agent_id))
+        logger.debug('#{} Sending policy'.format(msg.agent_id))
         policy = self.agents[msg.agent_id].get_policy()
         return messages.PolicyMessage(msg.agent_id, policy)
 
     def _set_agent_policy(self, msg):
-        logger.info('#{} Receiving policy'.format(msg.agent_id))
+        logger.debug('#{} Receiving policy'.format(msg.agent_id))
         self.agents[msg.agent_id].set_policy(msg.policy)
         return messages.AcknowledgementMessage()
 
@@ -144,10 +143,10 @@ def build_controller(agents_path, context=None, endpoint=None,
 
     if context and endpoint:
         server = communication.InprocServer(context, endpoint)
-        logger.info('Connecting with inproc communication')
+        logger.debug('Connecting with inproc communication')
     else:
         server = communication.TCPServer(port)
-        logger.info('Connecting with TCP communication (port {})'.format(port))
+        logger.debug('Connecting with TCP communication (port {})'.format(port))
 
     return Controller(server=server)
 

--- a/multiagentrl/controller.py
+++ b/multiagentrl/controller.py
@@ -22,8 +22,8 @@ __email__ = "matheus.v.portela@gmail.com"
 
 
 # Logging configuration
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('Controller')
+logger.setLevel(logging.INFO)
 
 
 class Controller(core.BaseController):
@@ -89,11 +89,11 @@ class Controller(core.BaseController):
         ally_ids = self._get_allies(agent_id)
         enemy_ids = self._get_enemies(agent_id)
 
-        if agent_id in self.agents:
-            del self.agents[agent_id]
+        if agent_id not in self.agents:
+            self.agents[agent_id] = self.agent_classes[agent_id](
+                agent_id, ally_ids, enemy_ids)
 
-        self.agents[agent_id] = self.agent_classes[agent_id](
-            agent_id, ally_ids, enemy_ids)
+        self.agents[agent_id].start_game()
 
         return messages.AcknowledgementMessage(
             ally_ids=ally_ids, enemy_ids=enemy_ids)
@@ -110,6 +110,7 @@ class Controller(core.BaseController):
 
     def _finish_game(self, msg):
         logger.info('#{} Finishing game'.format(msg.agent_id))
+        self.agents[msg.agent_id].finish_game()
         self.game_number[msg.agent_id] += 1
         return messages.AcknowledgementMessage()
 

--- a/multiagentrl/core.py
+++ b/multiagentrl/core.py
@@ -99,6 +99,14 @@ class BaseControllerAgent(object):
         """Set an action selection policy."""
         pass
 
+    def start_game(self):
+        """Execute before starting a new game."""
+        raise NotImplementedError
+
+    def stop_game(self):
+        """Execute after finishing a new game."""
+        raise NotImplementedError
+
     def learn(self, state, action, reward):
         """Learn from received reward after executing an action.
 

--- a/multiagentrl/learning.py
+++ b/multiagentrl/learning.py
@@ -11,7 +11,11 @@ In order to achieve that, all classes must inherit from BaseLearningAlgorithm
 and implement its virtual methods.
 """
 
+import logging
 import random
+
+# Logging configuration
+logger = logging.getLogger(__name__)
 
 __author__ = "Matheus Portela and Guilherme N. Ramos"
 __credits__ = ["Matheus Portela", "Guilherme N. Ramos", "Renato Nobre",
@@ -190,6 +194,11 @@ class QLearning(BaseLearningAlgorithm):
         action -- Executed action.
         reward -- Reward received after executing the action.
         """
+        logger.debug('Previous state: {}'.format(self.previous_state))
+        logger.debug('Current state: {}'.format(state))
+        logger.debug('Action: {}'.format(action))
+        logger.debug('Reward: {}'.format(reward))
+
         old_value = self.get_q_value(self.previous_state, action)
         next_expected_value = self.get_max_q_value(state)
         new_value = (old_value + self.learning_rate * (reward +
@@ -198,6 +207,8 @@ class QLearning(BaseLearningAlgorithm):
                                                        old_value))
         self.set_q_value(self.previous_state, action, new_value)
         self.update_state(state)
+
+        logger.debug('Q-values:\n{}'.format(self))
 
     def act(self, state):
         """Select the best legal action for the given state.

--- a/multiagentrl/learning.py
+++ b/multiagentrl/learning.py
@@ -93,12 +93,23 @@ class QLearning(BaseLearningAlgorithm):
     def __str__(self):
         """Generates Q-values string representation."""
         results = []
-        results.append('Q-values\n')
-        for state in self.q_values:
-            results.append(str(state))
+
+        # Print table header
+        results.append('Q-values ')
+        for action in self.actions:
+            results.append('{0: ^9}    '.format(str(action)))
+        results.append('\n')
+
+        # Print Q-values
+        for state in sorted(self.q_values):
+            results.append('{0: >4}:    '.format(str(state)))
             for action in self.q_values[state]:
-                results.append(str(self.q_values[state][action]))
-                results.append('\t')
+                q_value = self.q_values[state][action]
+
+                if q_value == 0.0:
+                    results.append('{0: >9}    '.format('0'))
+                else:
+                    results.append('{0:+f}    '.format(q_value))
             results.append('\n')
         return ''.join(results)
 


### PR DESCRIPTION
Besides changing the messages ordering in act-reward-learn feedback loop, the learning rate was decaying too quickly, avoiding learning at all. Making it be static was enough for this experiment.